### PR TITLE
Allow transformers-0.6

### DIFF
--- a/pipes-bytestring.cabal
+++ b/pipes-bytestring.cabal
@@ -24,7 +24,7 @@ Library
         pipes-group  >= 1.0.0   && < 1.1 ,
         pipes-parse  >= 3.0.0   && < 3.1 ,
         stringsearch >= 0.3.0   && < 0.4 ,
-        transformers >= 0.2.0.0 && < 0.6
+        transformers >= 0.2.0.0 && < 0.7
     Exposed-Modules: Pipes.ByteString
     GHC-Options: -O2 -Wall
     Default-Language: Haskell2010


### PR DESCRIPTION
Tested using:

```
cabal-3.10.1.0 build -w ghc-9.6.1
```

Which did succeed.
